### PR TITLE
Update yarn task to prevent report on spec failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "yarn test --watch",
     "clean:coverage": "rimraf coverage",
     "test:coverage": "yarn clean:coverage && yarn test --coverage",
-    "test:coverage:coveralls": "yarn test:coverage --ci --coverageReporters=text-lcov | coveralls",
+    "test:coverage:coveralls": "yarn test:coverage --ci && cat ./coverage/lcov.info | coveralls",
     "watch-test": "jest --watch",
     "ci": "yarn build && yarn test:coverage:coveralls",
     "prepublishOnly": "yarn build"


### PR DESCRIPTION
Previously, the pipe operator will receive the failed jest process' error code and continue to execute coveralls. This updates the `test:coverage:coveralls` task to only continue if the jest test suite has passed.