### PR TITLE
Prevent input event from bubbling up to storybook

### DIFF
--- a/src/custom-meta-input/input/input.component.js
+++ b/src/custom-meta-input/input/input.component.js
@@ -49,17 +49,22 @@ const TextNode = styled.span`
 `
 
 const Input = ({ value, onChange }) => {
-  function handleInputKeyDown({ key }) {
+  function handleInputKeyDown(event) {
+    const { key } = event
+
     switch (key) {
       case 'Backspace':
+        event.stopPropagation()
         return handleDeleteText()
       case ' ':
+        event.stopPropagation()
         return handleTextInput(key)
       default:
         break
       }
 
     if (/^.{1}$/.test(key)) {
+      event.stopPropagation()
       return handleTextInput(key)
     }
   }


### PR DESCRIPTION
This fixes the issue where storybook shortcut keys are activated while typing into the input box