### PR TITLE
Version bump v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "custom-meta-input",
-  "version": "0.0.1",
-  "description": "An input component largely inspired by Zapier's setup flow",
+  "version": "0.1.0",
+  "description": "An input/combobox component allowing you to combine user input and user-selected meta data",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "author": "Frankie Yan <frankieyan@gmail.com>",

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ To take a look at the component, check out its [Storybook demo](https://frankiey
 
 ### What can be improved?
 * **Movable text cursor** - The current version only supports inserting and deleting text/meta data from the end of the string.
-* **Selection** - Zapier's component allows you to select the contents of the input element, including the meta data badges, enabling you to copy and paste them around. I haven't thought of how to do this yet =)
+* **Selection** - Support text replacement as well as copy/cut/paste once a selection was made.
 * **Customizable data interface** - Currently, the `type` and `value` properties are expected. The interpolation string formats should also be customizable.
 * **Custom styling** - Allow custom styling or replacement UI components to be passed in.
 * **Accessibility** - The component should support keyboard interactions and the focus states managed as described in https://www.w3.org/TR/wai-aria-practices-1.1/#combobox


### PR DESCRIPTION
* Add [storybook-deployer](https://github.com/storybookjs/storybook-deployer) to deploy component demo to gh-pages
* Add test coverage reporting
* Add specs for the component
* Bump vulnerable packages reported by GitHub (jest, rollup-plugin-babel, etc)
* Support text and meta pill selection, and deleting of selected elements